### PR TITLE
bump sidekiq dependency 3

### DIFF
--- a/sidekiq-dynamic-queues.gemspec
+++ b/sidekiq-dynamic-queues.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |s|
   s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
   s.require_paths = ["lib"]
 
-  s.add_dependency("sidekiq", '~> 2.9')
+  s.add_dependency("sidekiq", '~> 3')
 
   s.add_development_dependency('rake')
   s.add_development_dependency('rspec', '~> 2.5')


### PR DESCRIPTION
Hello,

sidekiq 3.x have been released 4 months ago, time to bump dependency :+1: 

Cheers,
Stephane.
