### PR TITLE
add support for sidekiq 4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,6 @@ services:
   - redis-server
 
 rvm:
-  - 1.9.3
   - 2.1.1
   - jruby-19mode # JRuby in 1.9 mode
   - rbx

--- a/lib/sidekiq/dynamic_queues/fetch.rb
+++ b/lib/sidekiq/dynamic_queues/fetch.rb
@@ -26,10 +26,16 @@ module Sidekiq
           queues = expand_queues(@dynamic_queues)
           queues = @strictly_ordered_queues ? queues : queues.shuffle
           queues << "queue:default" if queues.size == 0
-          queues << Sidekiq::Fetcher::TIMEOUT
+          queues << get_timeout
         end
       end
-      
+
+      def get_timeout
+        Sidekiq::Fetcher::TIMEOUT
+      rescue NameError
+        Sidekiq::BasicFetch::TIMEOUT
+      end
+
       def self.translate_from_cli(*queues)
         queues.collect do |queue|
           queue.gsub('.star.', '*').gsub('.at.', '@').gsub('.not.', '!')

--- a/lib/sidekiq/dynamic_queues/fetch.rb
+++ b/lib/sidekiq/dynamic_queues/fetch.rb
@@ -26,6 +26,7 @@ module Sidekiq
           queues = expand_queues(@dynamic_queues)
           queues = @strictly_ordered_queues ? queues : queues.shuffle
           queues << "queue:default" if queues.size == 0
+          queues = queues.shuffle.uniq
           queues << get_timeout
         end
       end

--- a/lib/sidekiq/dynamic_queues/version.rb
+++ b/lib/sidekiq/dynamic_queues/version.rb
@@ -1,5 +1,5 @@
 module Sidekiq
   module DynamicQueues
-    VERSION = "1.0.0"
+    VERSION = "1.0.1"
   end
 end

--- a/sidekiq-dynamic-queues.gemspec
+++ b/sidekiq-dynamic-queues.gemspec
@@ -27,6 +27,8 @@ Gem::Specification.new do |s|
   s.add_development_dependency('slim')
   s.add_development_dependency('rack-test', '~> 0.5.4')
   s.add_development_dependency('tilt', '~> 1.4')
+  s.add_development_dependency('tilt', '~> 1.4')
+  s.add_development_dependency('celluloid', '~> 0.17.2')
 
 end
 

--- a/sidekiq-dynamic-queues.gemspec
+++ b/sidekiq-dynamic-queues.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |s|
   s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
   s.require_paths = ["lib"]
 
-  s.add_dependency("sidekiq", '~> 3')
+  s.add_dependency("sidekiq", ">= 3", "< 5")
 
   s.add_development_dependency('rake')
   s.add_development_dependency('rspec', '~> 2.5')


### PR DESCRIPTION
In [Sidekiq 4](http://www.mikeperham.com/2015/11/16/sidekiq-4.0/), the `Sidekiq::Fetcher` class was removed, and the `TIMEOUT` constant now lives on `Sidekiq::BasicFetch`. This PR changes the `Sidekiq::DynamicQueues::Fetch` class so that it can use either, and works with both Sidekiq 3 and 4.

I also bumped the version to 1.0.1.
